### PR TITLE
feat: separate hello cmd test + move validation logic to common location

### DIFF
--- a/src/handler/atomic_counter_handler.go
+++ b/src/handler/atomic_counter_handler.go
@@ -10,15 +10,7 @@ import (
 // https://redis.io/docs/latest/commands/incr/
 // https://redis.io/docs/latest/commands/decr/
 func handleAtomicUnitDelta(cmdArray data.Array, strg storage.StorageEngine, isDecrement bool) data.Message {
-	cmdLen := len(cmdArray.Elements)
-	if cmdLen < 2 {
-		return INVALID_CMD_ARGS
-	}
-
-	key, ok := cmdArray.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
+	key := cmdArray.Elements[1].(data.BulkString)
 
 	delta := int64(1)
 	if isDecrement {

--- a/src/handler/cmd_handler_atomic_counter_test.go
+++ b/src/handler/cmd_handler_atomic_counter_test.go
@@ -86,7 +86,7 @@ func TestHandleAtomicCounterCommands(t *testing.T) {
 					data.BulkString{Data: "INCR"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'incr' command"},
 		},
 		{
 			data.Array{
@@ -94,7 +94,7 @@ func TestHandleAtomicCounterCommands(t *testing.T) {
 					data.BulkString{Data: "DECR"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'decr' command"},
 		},
 		{
 			data.Array{
@@ -103,7 +103,7 @@ func TestHandleAtomicCounterCommands(t *testing.T) {
 					data.SimpleString{Contents: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{
@@ -112,7 +112,7 @@ func TestHandleAtomicCounterCommands(t *testing.T) {
 					data.SimpleString{Contents: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 	}
 

--- a/src/handler/cmd_handler_config_test.go
+++ b/src/handler/cmd_handler_config_test.go
@@ -22,7 +22,7 @@ func TestHandleConfigCommand(t *testing.T) {
 					data.BulkString{Data: "CONFIG"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'config' command"},
 		},
 		{
 			data.Array{
@@ -31,7 +31,7 @@ func TestHandleConfigCommand(t *testing.T) {
 					data.SimpleString{Contents: "GET"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{

--- a/src/handler/cmd_handler_del_test.go
+++ b/src/handler/cmd_handler_del_test.go
@@ -22,7 +22,7 @@ func TestHandleDelCommand(t *testing.T) {
 					data.BulkString{Data: "DEL"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'del' command"},
 		},
 		{
 			data.Array{
@@ -31,7 +31,7 @@ func TestHandleDelCommand(t *testing.T) {
 					data.Integer{Value: 12},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{

--- a/src/handler/cmd_handler_echo_test.go
+++ b/src/handler/cmd_handler_echo_test.go
@@ -29,9 +29,18 @@ func TestHandleEchoCommand(t *testing.T) {
 			data.Array{
 				Elements: []data.Message{
 					data.BulkString{Data: "ECHO"},
+					data.SimpleString{Contents: "hello world"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
+		},
+		{
+			data.Array{
+				Elements: []data.Message{
+					data.BulkString{Data: "ECHO"},
+				},
+			},
+			data.Error{ErrMsg: "wrong number of arguments for 'echo' command"},
 		},
 	}
 

--- a/src/handler/cmd_handler_get_test.go
+++ b/src/handler/cmd_handler_get_test.go
@@ -22,7 +22,7 @@ func TestHandleGetCommand(t *testing.T) {
 					data.BulkString{Data: "GET"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'get' command"},
 		},
 		{
 			data.Array{
@@ -31,7 +31,7 @@ func TestHandleGetCommand(t *testing.T) {
 					data.Integer{Value: 1},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{

--- a/src/handler/cmd_handler_hello_test.go
+++ b/src/handler/cmd_handler_hello_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/vrajashkr/cc-kv-go/src/storage"
 )
 
-func TestHandleExistsCommand(t *testing.T) {
+func TestHandleHelloCommand(t *testing.T) {
 	storageEngine := storage.NewMapStorageEngine()
 
 	testCases := []struct {
@@ -19,26 +19,17 @@ func TestHandleExistsCommand(t *testing.T) {
 		{
 			data.Array{
 				Elements: []data.Message{
-					data.BulkString{Data: "EXISTS"},
+					data.BulkString{Data: "HELLO"},
+					data.BulkString{Data: "3"},
 				},
 			},
-			data.Error{ErrMsg: "wrong number of arguments for 'exists' command"},
+			data.Error{ErrMsg: "NOPROTO sorry, this protocol version is not supported"},
 		},
 		{
 			data.Array{
 				Elements: []data.Message{
-					data.BulkString{Data: "EXISTS"},
-					data.Integer{Value: 12},
-				},
-			},
-			data.Error{ErrMsg: "invalid format for command"},
-		},
-		{
-			data.Array{
-				Elements: []data.Message{
-					data.BulkString{Data: "SET"},
-					data.BulkString{Data: "testKey"},
-					data.BulkString{Data: "testVal"},
+					data.BulkString{Data: "HELLO"},
+					data.BulkString{Data: "2"},
 				},
 			},
 			data.SimpleString{Contents: "OK"},
@@ -46,13 +37,11 @@ func TestHandleExistsCommand(t *testing.T) {
 		{
 			data.Array{
 				Elements: []data.Message{
-					data.BulkString{Data: "EXISTS"},
-					data.BulkString{Data: "testKey"},
-					data.BulkString{Data: "testNoKey"},
-					data.BulkString{Data: "testKey"},
+					data.BulkString{Data: "HELLO"},
+					data.BulkString{Data: "nan"},
 				},
 			},
-			data.Integer{Value: 2},
+			data.Error{ErrMsg: "invalid args for command"},
 		},
 	}
 

--- a/src/handler/cmd_handler_list_operation_test.go
+++ b/src/handler/cmd_handler_list_operation_test.go
@@ -23,7 +23,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.BulkString{Data: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'lpush' command"},
 		},
 		{
 			data.Array{
@@ -33,7 +33,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.SimpleString{Contents: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{
@@ -43,7 +43,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.BulkString{Data: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{
@@ -52,7 +52,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.BulkString{Data: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'rpush' command"},
 		},
 		{
 			data.Array{
@@ -62,7 +62,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.BulkString{Data: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{
@@ -72,7 +72,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.SimpleString{Contents: "ctr1"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{
@@ -80,7 +80,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.BulkString{Data: "LPUSH"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'lpush' command"},
 		},
 		{
 			data.Array{
@@ -88,7 +88,7 @@ func TestHandleListOperationCommands(t *testing.T) {
 					data.BulkString{Data: "RPUSH"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'rpush' command"},
 		},
 		{
 			data.Array{

--- a/src/handler/cmd_handler_ping_test.go
+++ b/src/handler/cmd_handler_ping_test.go
@@ -33,6 +33,15 @@ func TestHandlePingCommand(t *testing.T) {
 			},
 			data.BulkString{Data: "hello world"},
 		},
+		{
+			data.Array{
+				Elements: []data.Message{
+					data.BulkString{Data: "PING"},
+					data.SimpleString{Contents: "hello world"},
+				},
+			},
+			data.Error{ErrMsg: "invalid format for command"},
+		},
 	}
 
 	assert := assert.New(t)

--- a/src/handler/cmd_handler_set_test.go
+++ b/src/handler/cmd_handler_set_test.go
@@ -24,7 +24,7 @@ func TestHandleSetCommand(t *testing.T) {
 					data.BulkString{Data: "SET"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'set' command"},
 		},
 		{
 			data.Array{
@@ -33,7 +33,7 @@ func TestHandleSetCommand(t *testing.T) {
 					data.BulkString{Data: "testKey"},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "wrong number of arguments for 'set' command"},
 		},
 		{
 			data.Array{
@@ -43,7 +43,7 @@ func TestHandleSetCommand(t *testing.T) {
 					data.Integer{Value: 1},
 				},
 			},
-			data.Error{ErrMsg: "invalid args for command"},
+			data.Error{ErrMsg: "invalid format for command"},
 		},
 		{
 			data.Array{

--- a/src/handler/cmd_handler_test.go
+++ b/src/handler/cmd_handler_test.go
@@ -36,33 +36,6 @@ func TestHandleCommand(t *testing.T) {
 			},
 			data.Error{ErrMsg: "unsupported command UNSUPPORTED"},
 		},
-		{
-			data.Array{
-				Elements: []data.Message{
-					data.BulkString{Data: "HELLO"},
-					data.BulkString{Data: "3"},
-				},
-			},
-			data.Error{ErrMsg: "NOPROTO sorry, this protocol version is not supported"},
-		},
-		{
-			data.Array{
-				Elements: []data.Message{
-					data.BulkString{Data: "HELLO"},
-					data.BulkString{Data: "2"},
-				},
-			},
-			data.SimpleString{Contents: "OK"},
-		},
-		{
-			data.Array{
-				Elements: []data.Message{
-					data.BulkString{Data: "HELLO"},
-					data.BulkString{Data: "nan"},
-				},
-			},
-			data.Error{ErrMsg: "invalid args for command"},
-		},
 	}
 
 	assert := assert.New(t)

--- a/src/handler/config_handler.go
+++ b/src/handler/config_handler.go
@@ -8,14 +8,7 @@ import (
 
 // https://redis.io/docs/latest/commands/config-get/
 func handleConfig(cmdArray data.Array) data.Message {
-	if len(cmdArray.Elements) < 2 {
-		return INVALID_CMD_ARGS
-	}
-
-	subCommandHolder, ok := cmdArray.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
+	subCommandHolder := cmdArray.Elements[1].(data.BulkString)
 
 	switch subCommandHolder.Data {
 	case "GET":

--- a/src/handler/del_handler.go
+++ b/src/handler/del_handler.go
@@ -8,18 +8,10 @@ import (
 // https://redis.io/docs/latest/commands/del/
 func handleDelete(cmd data.Array, strg storage.StorageEngine) data.Message {
 	cmdLen := len(cmd.Elements)
-	if cmdLen < 2 {
-		return INVALID_CMD_ARGS
-	}
-
 	keys := make([]string, cmdLen-1)
 
 	for idx := range cmdLen - 1 {
-		keyToCheck, ok := cmd.Elements[1+idx].(data.BulkString)
-		if !ok {
-			return INVALID_CMD_ARGS
-		}
-
+		keyToCheck := cmd.Elements[1+idx].(data.BulkString)
 		keys[idx] = keyToCheck.Data
 	}
 

--- a/src/handler/echo_handler.go
+++ b/src/handler/echo_handler.go
@@ -4,13 +4,5 @@ import "github.com/vrajashkr/cc-kv-go/src/data"
 
 // https://redis.io/commands/echo/
 func handleEcho(cmd data.Array) data.Message {
-	if len(cmd.Elements) < 2 {
-		return INVALID_CMD_ARGS
-	}
-
-	incomingContents, ok := cmd.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
-	return incomingContents
+	return cmd.Elements[1].(data.BulkString)
 }

--- a/src/handler/exists_handler.go
+++ b/src/handler/exists_handler.go
@@ -8,18 +8,11 @@ import (
 // https://redis.io/docs/latest/commands/exists/
 func handleExists(cmd data.Array, strg storage.StorageEngine) data.Message {
 	cmdLen := len(cmd.Elements)
-	if cmdLen < 2 {
-		return INVALID_CMD_ARGS
-	}
 
 	keys := make([]string, cmdLen-1)
 
 	for idx := range cmdLen - 1 {
-		keyToCheck, ok := cmd.Elements[1+idx].(data.BulkString)
-		if !ok {
-			return INVALID_CMD_ARGS
-		}
-
+		keyToCheck := cmd.Elements[1+idx].(data.BulkString)
 		keys[idx] = keyToCheck.Data
 	}
 

--- a/src/handler/get_handler.go
+++ b/src/handler/get_handler.go
@@ -7,15 +7,7 @@ import (
 
 // https://redis.io/docs/latest/commands/get/
 func handleGet(cmd data.Array, strg storage.StorageEngine) data.Message {
-	if len(cmd.Elements) < 2 {
-		return INVALID_CMD_ARGS
-	}
-
-	keyHolder, ok := cmd.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
-
+	keyHolder := cmd.Elements[1].(data.BulkString)
 	ok, val, err := strg.Get(keyHolder.Data)
 	if err != nil {
 		return data.Error{ErrMsg: "failed to retrieve data due to error: " + err.Error()}

--- a/src/handler/hello_handler.go
+++ b/src/handler/hello_handler.go
@@ -9,15 +9,14 @@ import (
 
 // https://redis.io/docs/latest/commands/hello/
 func handleHello(cmd data.Array) data.Message {
-	versionEntry, ok := cmd.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_FMT
-	}
+	versionEntry := cmd.Elements[1].(data.BulkString)
+
 	versionRequested, err := strconv.Atoi(versionEntry.Data)
 	if err != nil {
 		slog.Error("invalid command args", "error", err.Error())
 		return INVALID_CMD_ARGS
 	}
+
 	if versionRequested != 2 {
 		return data.Error{ErrMsg: "NOPROTO sorry, this protocol version is not supported"}
 	}

--- a/src/handler/input_handler.go
+++ b/src/handler/input_handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/vrajashkr/cc-kv-go/src/data"
@@ -11,7 +10,7 @@ import (
 func ServeInput(rawData []byte, storage storage.StorageEngine) string {
 	rawStr := string(rawData)
 	rawStrLen := len(rawStr)
-	slog.Info(fmt.Sprintf("received message: %q", rawStr))
+	slog.Debug("received message", "msg", rawStr)
 	numProcessedChars := 0
 	result := ""
 
@@ -27,6 +26,6 @@ func ServeInput(rawData []byte, storage storage.StorageEngine) string {
 			break
 		}
 	}
-
+	slog.Debug("response", "resp", result)
 	return result
 }

--- a/src/handler/list_handler.go
+++ b/src/handler/list_handler.go
@@ -9,14 +9,8 @@ import (
 // https://redis.io/docs/latest/commands/rpush/
 func handleListPush(cmdArray data.Array, strg storage.StorageEngine, isPrepend bool) data.Message {
 	cmdLen := len(cmdArray.Elements)
-	if cmdLen < 3 {
-		return INVALID_CMD_ARGS
-	}
 
-	listToUpdate, ok := cmdArray.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
+	listToUpdate := cmdArray.Elements[1].(data.BulkString)
 
 	listNameToUpdate := listToUpdate.Data
 

--- a/src/handler/ping_handler.go
+++ b/src/handler/ping_handler.go
@@ -10,9 +10,5 @@ func handlePing(cmd data.Array) data.Message {
 		return data.SimpleString{Contents: "PONG"}
 	}
 
-	incomingContents, ok := cmd.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
-	return incomingContents
+	return cmd.Elements[1].(data.BulkString)
 }

--- a/src/handler/set_handler.go
+++ b/src/handler/set_handler.go
@@ -11,20 +11,8 @@ import (
 // https://redis.io/docs/latest/commands/set/
 func handleSet(cmd data.Array, strg storage.StorageEngine) data.Message {
 	numArgs := len(cmd.Elements)
-
-	if numArgs < 3 {
-		return INVALID_CMD_ARGS
-	}
-
-	keyHolder, ok := cmd.Elements[1].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
-
-	valueHolder, ok := cmd.Elements[2].(data.BulkString)
-	if !ok {
-		return INVALID_CMD_ARGS
-	}
+	keyHolder := cmd.Elements[1].(data.BulkString)
+	valueHolder := cmd.Elements[2].(data.BulkString)
 
 	valueContents := valueHolder.Data
 	expires := false


### PR DESCRIPTION
Closes #13 

This PR:
- moves common validation to the command handler to reduce code duplication.
- separates out the hello cmd test that was left over from #12
- adds debug logs for message received and response